### PR TITLE
added a safety check to inform the user to run the cert scripts first

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if [ ! -f ./certs/kafka.truststore.jks ]; then
+    echo "create the keystore files before running this script"
+    exit;    
+fi
+
+
+
 orb start k8s
 
 # Create shared namespace


### PR DESCRIPTION
I added a simple safety check that asks the user the run the cert creation scripts first before deploying the solution stack