### PR TITLE
[DO NOT MERGE] Reproduce ZD ticket 2247 with 3 controller and 4 normal broker

### DIFF
--- a/generate-tls.sh
+++ b/generate-tls.sh
@@ -146,8 +146,26 @@ create_truststore() {
 clean_certificates
 create_ca
 create_truststore
-create_certificate kafka franz-kafka.conduktor.svc.cluster.local *.franz-kafka-controller-headless.conduktor.svc.cluster.local
-create_certificate gateway.conduktor.k8s.orb.local brokermain0-gateway.conduktor.k8s.orb.local brokermain1-gateway.conduktor.k8s.orb.local brokermain2-gateway.conduktor.k8s.orb.local
+
+create_certificate kafka \
+    franz-kafka.conduktor.svc.cluster.local \
+    *.franz-kafka-controller-headless.conduktor.svc.cluster.local \
+    *.franz-kafka-broker-headless.conduktor.svc.cluster.local
+
+create_certificate gateway.conduktor.k8s.orb.local \
+    brokermain0-gateway.conduktor.k8s.orb.local \
+    brokermain1-gateway.conduktor.k8s.orb.local \
+    brokermain2-gateway.conduktor.k8s.orb.local \
+    brokermain3-gateway.conduktor.k8s.orb.local \
+    brokermain4-gateway.conduktor.k8s.orb.local \
+    brokermain5-gateway.conduktor.k8s.orb.local \
+    brokermain100-gateway.conduktor.k8s.orb.local \
+    brokermain101-gateway.conduktor.k8s.orb.local \
+    brokermain102-gateway.conduktor.k8s.orb.local \
+    brokermain103-gateway.conduktor.k8s.orb.local \
+    brokermain104-gateway.conduktor.k8s.orb.local \
+    brokermain105-gateway.conduktor.k8s.orb.local
+
 create_certificate console.conduktor.k8s.orb.local
 
 cp ${CA_PATH}/truststore.jks ${CA_PATH}/kafka.truststore.jks 

--- a/helm/kafka-values.yml
+++ b/helm/kafka-values.yml
@@ -1,6 +1,10 @@
 # helm install kafka oci://registry-1.docker.io/bitnamicharts/kafka
 
-replicaCount: 3
+controller:
+  replicaCount: 3
+
+broker:
+  replicaCount: 4
 
 listeners:
   client:

--- a/start.sh
+++ b/start.sh
@@ -52,9 +52,11 @@ kubectl -n conduktor \
 # Install components
 
 # Install Kafka via Bitnami's Kafka helm chart
+# The newer chart version is broken, so we have to explicitly specify the chart version
 helm install \
     -f ./helm/kafka-values.yml \
     -n conduktor \
+    --version 31.5.0 \
     franz oci://registry-1.docker.io/bitnamicharts/kafka
 
 # Add helm repos


### PR DESCRIPTION
We want to see the actual behaviour of Gateway when the controller ID's are 0-2 and broker ID's are 100-103. This test shows that Gateway generates hostnames based on their ID. So the certificate needs to take that into account when adding SAN.