### PR TITLE
Fix helm values + JDK guidance so tutorial deploys with current tooling

### DIFF
--- a/helm/gateway-values.yml
+++ b/helm/gateway-values.yml
@@ -39,7 +39,7 @@ gateway:
   volumeMounts:
     - name: truststore
       mountPath: /etc/gateway/tls/truststore/
-      readonly: true
+      readOnly: true
 
 tls:
   enable: true

--- a/helm/kafka-values.yml
+++ b/helm/kafka-values.yml
@@ -2,6 +2,14 @@
 
 replicaCount: 3
 
+global:
+  security:
+    allowInsecureImages: true
+
+image:
+  registry: docker.io
+  repository: bitnamilegacy/kafka
+
 listeners:
   client:
     protocol: SASL_SSL

--- a/readme.md
+++ b/readme.md
@@ -207,11 +207,14 @@ curl \
 
 Next we will look at connecting a Kafka client.
 
-In newer JDKs, Java clients need to run with this env var set (see [KIP 1006](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1006%3A+Remove+SecurityManager+Support)):
-```bash
-export KAFKA_OPTS="-Djava.security.manager=allow"
-```
-You can also add ` -Djavax.net.debug=ssl` to enable ssl debug messages.
+> **JDK note:** Some older guides recommend setting `KAFKA_OPTS="-Djava.security.manager=allow"` per [KIP-1006](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1006%3A+Remove+SecurityManager+Support). The flag is only useful on **JDK 17–23 with Kafka 3.x clients** (where Kafka client code transitively touched the SecurityManager API).
+> - On **Kafka 4.x clients** — what `brew install kafka` gives you today — KIP-1006 removed the relevant code path, so the flag does nothing useful.
+> - On **JDK 24+** ([JEP 486](https://openjdk.org/jeps/486) removed the SecurityManager API entirely) the flag is *rejected* and the JVM refuses to start with a `Security Manager is not supported` error.
+>
+> Leave `KAFKA_OPTS` unset unless you have a specific reason. You can still pass `-Djavax.net.debug=ssl` to enable SSL debug logging:
+> ```bash
+> export KAFKA_OPTS="-Djavax.net.debug=ssl"
+> ```
 
 Look at the hostnames in the metadata returned by Kafka.
 


### PR DESCRIPTION
## Summary

Three small fixes so a fresh `./scripts/start.sh` deploy + readme walkthrough actually works on current helm + Kubernetes + Bitnami image policy + JDK.

- **`helm/gateway-values.yml`**: rename `readonly: true` → `readOnly: true` on the gateway truststore volumeMount. The Kubernetes API field is camelCase `readOnly`; the lowercase variant is silently dropped by older helm/kubectl but rejected by helm v4 + recent kubectl with `field not declared in schema`.
- **`helm/kafka-values.yml`**: override the Bitnami Kafka image to `bitnamilegacy/kafka` and set `global.security.allowInsecureImages=true`. Bitnami moved free-tier community images from `docker.io/bitnami/*` to `docker.io/bitnamilegacy/*` in mid-2025; the image pinned by chart `31.1.0` (`bitnami/kafka:3.9.0-debian-12-r1`) now returns `manifest unknown`. The `allowInsecureImages` flag bypasses the chart's image-namespace validator (which would otherwise block any non-`bitnami/*` image). Newer chart versions still default to `bitnami/*` so they would need the same override.
- **`readme.md`**: rewrite the `KAFKA_OPTS=-Djava.security.manager=allow` recommendation. JDK 24+ removed the SecurityManager API entirely (JEP 486), so the flag is rejected at JVM startup — `brew install openjdk` (which defaults to 25) breaks the readme verbatim. Kafka 4.x clients no longer touch SecurityManager (KIP-1006), so the flag is also a no-op for current `brew install kafka`. The new prose scopes the flag to its actual remaining use case (JDK 17–23 + Kafka 3.x) and explains why it should be left unset otherwise.

Without these, `start.sh` fails with `ErrImagePull` on Kafka pods + a helm schema error on Gateway, and the Kafka client section of the readme fails the JVM before any Kafka work begins.

## Test plan
- [x] `./scripts/generate-tls.sh`
- [x] `./scripts/start.sh` — Kafka brokers reach `Running 1/1`, Gateway pods reach `Running 1/1` once a license is provided
- [x] `kubectl -n conduktor get svc gateway-external` returns an external IP
- [x] `curl --cacert ./certs/rootCA.crt -u admin:conduktor https://gateway.conduktor.k8s.tutorial:8888/gateway/v2/interceptor?global=false` returns `[]`
- [x] `kafka-broker-api-versions --bootstrap-server gateway.conduktor.k8s.tutorial:9092 --command-config client.properties` lists all 3 brokers under their `brokermain*-gateway` SNI hostnames
- [x] Topic create / produce / consume through Gateway round-trips a message end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)